### PR TITLE
[25] Switch pod-selector for network-policy to "k8s-ces-gateway" instead of nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [#25] Switch pod-selector for network-policy to "k8s-ces-gateway" instead of nginx
 
 ## [v75.3.5-2] - 2025-08-11
 ### Fixed

--- a/k8s/helm/templates/ingress-networkPolicy.yaml
+++ b/k8s/helm/templates/ingress-networkPolicy.yaml
@@ -18,7 +18,7 @@ spec:
           kubernetes.io/metadata.name: ecosystem
       podSelector:
         matchLabels:
-          dogu.name: nginx-ingress
+          k8s.cloudogu.com/component.name: k8s-ces-gateway
     ports:
       - port: auth-proxy
         protocol: TCP


### PR DESCRIPTION
closes #25 